### PR TITLE
Improved performance of elixir solution a bit

### DIFF
--- a/elixir/wordcount.ex
+++ b/elixir/wordcount.ex
@@ -1,18 +1,21 @@
 IO.stream(:stdio, :line)
 # Split the input in words and reject empty
 |> Stream.flat_map(&String.split(&1, ~r/\s/, strip: true))
-|> Stream.reject(&(&1 == ""))
 # Create a dictionary in which the keys are the words and the values are
 # the number of appearances in the input text.
-|> Enum.reduce(%{}, fn word, counter ->
-  Map.update(counter, word, 1, &(&1 + 1))
+|> Enum.reduce(%{}, fn
+  "",   counter -> counter # ignore “empty” words
+  word, counter ->
+    Map.update(counter, word, 1, &(&1 + 1))
 end)
-# Transform the dictionary into a list of tuples with the form {word, appearances}
-|> Map.to_list
 # Sort words
 |> Enum.sort(fn
   {word1, count1}, {word2, count1} -> word1 < word2 # If appearance count is equal, sort alphabetically
   {_, count1}, {_, count2} -> count1 > count2 # Sort by appearance count
 end)
-# Print the results
-|> Enum.each(fn ({word, count}) -> IO.puts("#{word}\t#{count}") end)
+# Prepare results for printing
+|> Stream.map(fn {word, count} -> [word, ?\t, Integer.to_string(count), ?\n] end)
+# Force the stream into a list
+|> Enum.into([])
+# and print!
+|> IO.puts


### PR DESCRIPTION
1. Removed `Stream.reject/2` call and moved it's functionality into the
   `Enum.reduce/3` (doing a pattern match).
2. Removed explicit conversion of the map to a list. Maps are already
   proper `Enum`s and can be fed into `Enum.sort/2`.
3. Preparing an IO-list and feeding this into `IO.puts/1`. This way
   does safe us up some function calls (less interference by the
   scheduler, also it reduces the amount of buffer flushes.